### PR TITLE
delete .works-title-detail box-shadow from style.css

### DIFF
--- a/style.css
+++ b/style.css
@@ -555,7 +555,6 @@ h2.works-title {
   color: #fafafa;
   margin: 10%;
   position: relative;
-  box-shadow: 0px 10px 10px 0px rgba(0, 0, 0, 0.5);
 }
 .works-wrapper:hover {
   transform: scale(1.1);


### PR DESCRIPTION
Works のタイトルの小見出しにかかっていたbox-shadowを消去しました